### PR TITLE
Add SimpleHouseDemo viewer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Tabs } from 'antd';
 import './App.css';
 import DemoIfcBuilding from './DemoIfcBuilding';
 import ThatOpenViewer from './components/ThatOpenViewer';
+import SimpleHouseDemo from './SimpleHouseDemo';
 import { IfcProvider } from './components/ifc';
 
 const App: FC = () => {
@@ -16,6 +17,11 @@ const App: FC = () => {
       key: '2',
       label: 'ThatOpen Viewer',
       children: <ThatOpenViewer />,
+    },
+    {
+      key: '3',
+      label: 'Simple House Demo',
+      children: <SimpleHouseDemo />,
     },
   ];
 

--- a/src/SimpleHouseDemo.tsx
+++ b/src/SimpleHouseDemo.tsx
@@ -1,0 +1,63 @@
+import type { FC } from 'react';
+import {
+  IfcProvider,
+  IfcSite,
+  IfcBuilding,
+  IfcBuildingStorey,
+  IfcWall,
+  IfcDoor,
+  IfcWindow,
+  IfcViewer3D
+} from './components/ifc';
+
+const SimpleHouseModel: FC = () => (
+  <IfcSite id="site">
+    <IfcBuilding id="building">
+      <IfcBuildingStorey id="storey">
+        <IfcWall
+          id="northWall"
+          position={{ x: 0, y: 0, z: 0 }}
+          dimensions={{ width: 4, height: 3, depth: 0.2 }}
+        />
+        <IfcWall
+          id="southWall"
+          position={{ x: 0, y: 0, z: 4 }}
+          dimensions={{ width: 4, height: 3, depth: 0.2 }}
+        >
+          <IfcDoor
+            id="mainDoor"
+            position={{ x: 1, y: 0, z: 0 }}
+            dimensions={{ width: 0.8, height: 2, depth: 0.2 }}
+          />
+        </IfcWall>
+        <IfcWall
+          id="eastWall"
+          position={{ x: 2, y: 0, z: 2 }}
+          dimensions={{ width: 0.2, height: 3, depth: 4 }}
+        >
+          <IfcWindow
+            id="eastWindow"
+            position={{ x: 0, y: 1, z: 1 }}
+            dimensions={{ width: 0.2, height: 1, depth: 1 }}
+          />
+        </IfcWall>
+        <IfcWall
+          id="westWall"
+          position={{ x: -2, y: 0, z: 2 }}
+          dimensions={{ width: 0.2, height: 3, depth: 4 }}
+        />
+      </IfcBuildingStorey>
+    </IfcBuilding>
+  </IfcSite>
+);
+
+const SimpleHouseDemo: FC = () => (
+  <IfcProvider>
+    <div style={{ width: '100%' }}>
+      <SimpleHouseModel />
+      <IfcViewer3D height={400} />
+    </div>
+  </IfcProvider>
+);
+
+export default SimpleHouseDemo;


### PR DESCRIPTION
## Summary
- create a simple demo house as React IFC components
- show it in a viewer and add a new tab in the app

## Testing
- `npm run lint`
- `npm run build` *(fails: BaseIfcElement, IfcToThatOpen TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_6851b481d504832d90526297d845b4e7