### PR TITLE
Add new IFC components and viewer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ export default tseslint.config({
 })
 ```
 
+## IFC React components
+
+This project exposes React components for several IFC entities. You can combine
+them in JSX to describe a basic building structure. Recently added components
+include `IfcProject`, `IfcCurtainWall`, `IfcFooting` and `IfcPile`.
+
+```tsx
+import {
+  IfcProject,
+  IfcSite,
+  IfcBuilding,
+  IfcBuildingStorey,
+  IfcWall,
+  IfcFooting
+} from './components/ifc';
+
+const MyModel = () => (
+  <IfcProject id="p1">
+    <IfcSite id="s1">
+      <IfcBuilding id="b1">
+        <IfcBuildingStorey id="storey">
+          <IfcWall id="wall1" />
+          <IfcFooting id="foot1" position={{ x: 0, y: -0.3, z: 0 }} />
+        </IfcBuildingStorey>
+      </IfcBuilding>
+    </IfcSite>
+  </IfcProject>
+);
+```
+
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js

--- a/src/SimpleHouseDemo.tsx
+++ b/src/SimpleHouseDemo.tsx
@@ -1,19 +1,22 @@
 import type { FC } from 'react';
 import {
   IfcProvider,
+  IfcProject,
   IfcSite,
   IfcBuilding,
   IfcBuildingStorey,
   IfcWall,
   IfcDoor,
   IfcWindow,
+  IfcFooting,
   IfcViewer3D
 } from './components/ifc';
 
 const SimpleHouseModel: FC = () => (
-  <IfcSite id="site">
-    <IfcBuilding id="building">
-      <IfcBuildingStorey id="storey">
+  <IfcProject id="project">
+    <IfcSite id="site">
+      <IfcBuilding id="building">
+        <IfcBuildingStorey id="storey">
         <IfcWall
           id="northWall"
           position={{ x: 0, y: 0, z: 0 }}
@@ -46,9 +49,15 @@ const SimpleHouseModel: FC = () => (
           position={{ x: -2, y: 0, z: 2 }}
           dimensions={{ width: 0.2, height: 3, depth: 4 }}
         />
+        <IfcFooting
+          id="foundation"
+          position={{ x: 0, y: -0.25, z: 2 }}
+          dimensions={{ width: 4, height: 0.5, depth: 4 }}
+        />
       </IfcBuildingStorey>
     </IfcBuilding>
-  </IfcSite>
+    </IfcSite>
+  </IfcProject>
 );
 
 const SimpleHouseDemo: FC = () => (

--- a/src/components/ifc/IfcComponents.tsx
+++ b/src/components/ifc/IfcComponents.tsx
@@ -43,6 +43,22 @@ export const IfcRoof: React.FC<BaseIfcElementProps> = (props) => {
   return <BaseIfcElement type="IfcRoof" {...props} />;
 };
 
+export const IfcCurtainWall: React.FC<BaseIfcElementProps> = (props) => {
+  return <BaseIfcElement type="IfcCurtainWall" {...props} />;
+};
+
+export const IfcFooting: React.FC<BaseIfcElementProps> = (props) => {
+  return <BaseIfcElement type="IfcFooting" {...props} />;
+};
+
+export const IfcPile: React.FC<BaseIfcElementProps> = (props) => {
+  return <BaseIfcElement type="IfcPile" {...props} />;
+};
+
+export const IfcProject: React.FC<BaseIfcElementProps> = (props) => {
+  return <BaseIfcElement type="IfcProject" {...props} />;
+};
+
 // Åpningselementer
 export const IfcWindow: React.FC<BaseIfcElementProps> = (props) => {
   return <BaseIfcElement type="IfcWindow" {...props} />;

--- a/src/components/ifc/IfcViewer3D.tsx
+++ b/src/components/ifc/IfcViewer3D.tsx
@@ -279,6 +279,55 @@ const IfcViewer3D = ({ width = '100%', height = 600 }: IfcViewer3DProps) => {
         });
         break;
         
+      case 'IfcCurtainWall':
+        geometry = new THREE.BoxGeometry(
+          dimensions.width || 1,
+          dimensions.height || 3,
+          dimensions.depth || 0.2
+        );
+        material = new THREE.MeshStandardMaterial({
+          color: 0xaaaaee,
+          transparent: true,
+          opacity: 0.5,
+          roughness: 0.2
+        });
+        break;
+      case 'IfcFooting':
+        geometry = new THREE.BoxGeometry(
+          dimensions.width || 1,
+          dimensions.height || 0.5,
+          dimensions.depth || 1
+        );
+        material = new THREE.MeshStandardMaterial({
+          color: 0x555555,
+          roughness: 0.8
+        });
+        break;
+      case 'IfcPile':
+        geometry = new THREE.CylinderGeometry(
+          dimensions.width / 2 || 0.25,
+          dimensions.width / 2 || 0.25,
+          dimensions.height || 2,
+          12
+        );
+        material = new THREE.MeshStandardMaterial({
+          color: 0x888888,
+          roughness: 0.7
+        });
+        break;
+      case 'IfcProject':
+        geometry = new THREE.BoxGeometry(
+          dimensions.width || 1,
+          dimensions.height || 1,
+          dimensions.depth || 1
+        );
+        material = new THREE.MeshStandardMaterial({
+          color: 0xffffff,
+          wireframe: true,
+          transparent: true,
+          opacity: 0.05
+        });
+        break;
       default:
         // Standard boks for andre elementer
         geometry = new THREE.BoxGeometry(

--- a/src/components/ifc/index.ts
+++ b/src/components/ifc/index.ts
@@ -25,6 +25,10 @@ export {
   IfcColumn,
   IfcSlab,
   IfcRoof,
+  IfcCurtainWall,
+  IfcFooting,
+  IfcPile,
+  IfcProject,
   
   // Åpningselementer
   IfcWindow,
@@ -51,4 +55,4 @@ export {
   // Gruppe og samling
   IfcElementAssembly,
   IfcSystem
-} from './IfcComponents'; 
+} from './IfcComponents';

--- a/src/converters/IfcToThatOpen.ts
+++ b/src/converters/IfcToThatOpen.ts
@@ -251,6 +251,18 @@ function createGeometry(
     case 'IfcRoof':
       mesh = createRoof(position, dimensions);
       break;
+    case 'IfcCurtainWall':
+      mesh = createCurtainWall(position, dimensions);
+      break;
+    case 'IfcFooting':
+      mesh = createFooting(position, dimensions);
+      break;
+    case 'IfcPile':
+      mesh = createPile(position, dimensions);
+      break;
+    case 'IfcProject':
+      mesh = createProject(position, dimensions);
+      break;
     case 'IfcSite':
       mesh = createSite(position, dimensions);
       break;
@@ -447,6 +459,71 @@ function createSpace(position: Position3D, dimensions: Dimensions3D): THREE.Mesh
   return mesh;
 }
 
+function createCurtainWall(position: Position3D, dimensions: Dimensions3D): THREE.Mesh {
+  const geometry = new THREE.BoxGeometry(
+    dimensions.width,
+    dimensions.height,
+    dimensions.depth
+  );
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xaaaaee,
+    transparent: true,
+    opacity: 0.5,
+    roughness: 0.2
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.set(position.x, position.y + dimensions.height / 2, position.z);
+  return mesh;
+}
+
+function createFooting(position: Position3D, dimensions: Dimensions3D): THREE.Mesh {
+  const geometry = new THREE.BoxGeometry(
+    dimensions.width,
+    dimensions.height,
+    dimensions.depth
+  );
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x555555,
+    roughness: 0.8
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.set(position.x, position.y + dimensions.height / 2, position.z);
+  return mesh;
+}
+
+function createPile(position: Position3D, dimensions: Dimensions3D): THREE.Mesh {
+  const geometry = new THREE.CylinderGeometry(
+    dimensions.width / 2,
+    dimensions.width / 2,
+    dimensions.height,
+    16
+  );
+  const material = new THREE.MeshStandardMaterial({
+    color: 0x888888,
+    roughness: 0.7
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.set(position.x, position.y + dimensions.height / 2, position.z);
+  return mesh;
+}
+
+function createProject(position: Position3D, dimensions: Dimensions3D): THREE.Mesh {
+  const geometry = new THREE.BoxGeometry(
+    dimensions.width || 1,
+    dimensions.height || 1,
+    dimensions.depth || 1
+  );
+  const material = new THREE.MeshStandardMaterial({
+    color: 0xffffff,
+    wireframe: true,
+    transparent: true,
+    opacity: 0.05
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.set(position.x, position.y + (dimensions.height || 1) / 2, position.z);
+  return mesh;
+}
+
 function createDefaultElement(position: Position3D, dimensions: Dimensions3D): THREE.Mesh {
   const geometry = new THREE.BoxGeometry(
     dimensions.width,
@@ -508,15 +585,27 @@ export function exportToIfc(data: IfcExportData): string {
       case 'IfcWindow':
         ifcLine = `IFCWINDOW('${element.id}', $, '${element.properties.name || 'Window'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, ${element.dimensions?.height || 1.2}, ${element.dimensions?.width || 1}, $, $)`;
         break;
-      case 'IfcDoor':
-        ifcLine = `IFCDOOR('${element.id}', $, '${element.properties.name || 'Door'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, ${element.dimensions?.height || 2.1}, ${element.dimensions?.width || 1}, $, $)`;
-        break;
-      case 'IfcColumn':
-        ifcLine = `IFCCOLUMN('${element.id}', $, '${element.properties.name || 'Column'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, $, $)`;
-        break;
-      default:
-        ifcLine = `IFCBUILDINGELEMENTPROXY('${element.id}', $, '${element.type}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, $, $, $)`;
-    }
+    case 'IfcDoor':
+      ifcLine = `IFCDOOR('${element.id}', $, '${element.properties.name || 'Door'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, ${element.dimensions?.height || 2.1}, ${element.dimensions?.width || 1}, $, $)`;
+      break;
+    case 'IfcColumn':
+      ifcLine = `IFCCOLUMN('${element.id}', $, '${element.properties.name || 'Column'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, $, $)`;
+      break;
+    case 'IfcCurtainWall':
+      ifcLine = `IFCCURTAINWALL('${element.id}', $, '${element.properties.name || 'CurtainWall'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, ${element.dimensions?.height || 3}, ${element.dimensions?.width || 1}, ${element.dimensions?.depth || 0.2}, $)`;
+      break;
+    case 'IfcFooting':
+      ifcLine = `IFCFOOTING('${element.id}', $, '${element.properties.name || 'Footing'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, ${element.dimensions?.height || 0.5}, ${element.dimensions?.width || 1}, ${element.dimensions?.depth || 1}, $)`;
+      break;
+    case 'IfcPile':
+      ifcLine = `IFCPILE('${element.id}', $, '${element.properties.name || 'Pile'}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, ${element.dimensions?.height || 1}, ${element.dimensions?.width || 0.5}, $)`;
+      break;
+    case 'IfcProject':
+      ifcLine = `IFCPROJECT('${element.id}', $, '${element.properties.name || 'Project'}', $, $, $, $, $, $)`;
+      break;
+    default:
+      ifcLine = `IFCBUILDINGELEMENTPROXY('${element.id}', $, '${element.type}', $, $, ${element.position?.x || 0}, ${element.position?.y || 0}, ${element.position?.z || 0}, $, $, $)`;
+  }
     
     output += `${ifcLine};\n`;
     idCounter++;


### PR DESCRIPTION
## Summary
- support additional IFC components (`IfcProject`, `IfcCurtainWall`, `IfcFooting`, `IfcPile`)
- render new elements in the viewer and converters
- update simple demo to use new components
- document usage of IFC components in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6851dab92f64832d82ee52eaa47161a2